### PR TITLE
feat: support english and japanese via react-i18next

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -30,6 +30,8 @@ export default defineConfig({
     baseURL: process.env.BASE_URL || "http://localhost:5173",
     // Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer
     trace: "on-first-retry",
+    // Fix the browser locale so language-dependent assertions are deterministic across environments.
+    locale: "en-US",
   },
 
   // Configure projects for major browsers

--- a/e2e/tests/language-toggle.spec.ts
+++ b/e2e/tests/language-toggle.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect, type Page } from "@playwright/test";
+
+function languageToggle(page: Page) {
+  // Both desktop and mobile headers render a toggle; only one is visible per viewport.
+  return page.locator('[data-testid="language-toggle"]:visible');
+}
+
+test.describe("Language Toggle", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+  });
+
+  test("should have language toggle button", async ({ page }) => {
+    await expect(languageToggle(page)).toBeVisible();
+  });
+
+  test("should switch displayed language when clicked", async ({ page }) => {
+    await expect(languageToggle(page)).toHaveAttribute("title", "Current language: English");
+
+    await languageToggle(page).click();
+
+    await expect(languageToggle(page)).toHaveAttribute("title", "現在の言語: 日本語");
+  });
+
+  test("should persist language preference across reload", async ({ page }) => {
+    await languageToggle(page).click();
+    await expect(languageToggle(page)).toHaveAttribute("title", "現在の言語: 日本語");
+
+    await page.reload();
+
+    await expect(languageToggle(page)).toHaveAttribute("title", "現在の言語: 日本語");
+  });
+});
+
+test.describe("Language Detection", () => {
+  test.use({ locale: "ja-JP" });
+
+  test("should default to Japanese when browser language is Japanese", async ({ page }) => {
+    await page.goto("/");
+    await expect(languageToggle(page)).toHaveAttribute("title", "現在の言語: 日本語");
+  });
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,9 +17,12 @@
     "@radix-ui/react-slot": "^1.2.5",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "i18next": "^26.3.4",
+    "i18next-browser-languagedetector": "^8.2.1",
     "lucide-react": "^1.17.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
+    "react-i18next": "^17.0.8",
     "react-router-dom": "^7.16.0",
     "tailwind-merge": "^3.6.0"
   },
@@ -39,7 +42,7 @@
     "prettier": "^3.8.3",
     "tailwindcss": "^4.3.0",
     "typescript": "~5.9.3",
-    "vite": "^8.0.16",
-    "typescript-eslint": "^8.60.1"
+    "typescript-eslint": "^8.60.1",
+    "vite": "^8.0.16"
   }
 }

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -26,6 +26,12 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      i18next:
+        specifier: ^26.3.4
+        version: 26.3.4(typescript@5.9.3)
+      i18next-browser-languagedetector:
+        specifier: ^8.2.1
+        version: 8.2.1
       lucide-react:
         specifier: ^1.17.0
         version: 1.17.0(react@19.2.7)
@@ -35,6 +41,9 @@ importers:
       react-dom:
         specifier: ^19.2.7
         version: 19.2.7(react@19.2.7)
+      react-i18next:
+        specifier: ^17.0.8
+        version: 17.0.8(i18next@26.3.4(typescript@5.9.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3)
       react-router-dom:
         specifier: ^7.16.0
         version: 7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -150,6 +159,10 @@ packages:
     resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/template@7.29.7':
     resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
@@ -935,6 +948,20 @@ packages:
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
+  html-parse-stringify@3.0.1:
+    resolution: {integrity: sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==}
+
+  i18next-browser-languagedetector@8.2.1:
+    resolution: {integrity: sha512-bZg8+4bdmaOiApD7N7BPT9W8MLZG+nPTOFlLiJiT8uzKXFjhxw4v2ierCXOwB5sFDMtuA5G4kgYZ0AznZxQ/cw==}
+
+  i18next@26.3.4:
+    resolution: {integrity: sha512-pa7m0d7pBDqGHZxljT+WPFeyFgQ7P7SciPPo1tTqYuO0z4sqADYhwnBESmmGp/wEof1inwdls/k8ZgTg8rxFHA==}
+    peerDependencies:
+      typescript: ^5 || ^6
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -1151,6 +1178,22 @@ packages:
     peerDependencies:
       react: ^19.2.7
 
+  react-i18next@17.0.8:
+    resolution: {integrity: sha512-0ooKbGLU8JXhe1zwpQUWIeXSgLPOfwJmgheWRIUpcoA0CpyabpGhayjdG+/eA5esC1AQ8h2jWpXjJfzQzeDOCw==}
+    peerDependencies:
+      i18next: '>= 26.2.0'
+      react: '>= 16.8.0'
+      react-dom: '*'
+      react-native: '*'
+      typescript: ^5 || ^6
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+      react-native:
+        optional: true
+      typescript:
+        optional: true
+
   react-remove-scroll-bar@2.3.8:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
     engines: {node: '>=10'}
@@ -1301,6 +1344,11 @@ packages:
       '@types/react':
         optional: true
 
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   vite@8.0.16:
     resolution: {integrity: sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1343,6 +1391,10 @@ packages:
         optional: true
       yaml:
         optional: true
+
+  void-elements@3.1.0:
+    resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
+    engines: {node: '>=0.10.0'}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -1447,6 +1499,8 @@ snapshots:
   '@babel/parser@7.29.7':
     dependencies:
       '@babel/types': 7.29.7
+
+  '@babel/runtime@7.29.7': {}
 
   '@babel/template@7.29.7':
     dependencies:
@@ -2159,6 +2213,18 @@ snapshots:
     dependencies:
       hermes-estree: 0.25.1
 
+  html-parse-stringify@3.0.1:
+    dependencies:
+      void-elements: 3.1.0
+
+  i18next-browser-languagedetector@8.2.1:
+    dependencies:
+      '@babel/runtime': 7.29.7
+
+  i18next@26.3.4(typescript@5.9.3):
+    optionalDependencies:
+      typescript: 5.9.3
+
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
@@ -2317,6 +2383,17 @@ snapshots:
       react: 19.2.7
       scheduler: 0.27.0
 
+  react-i18next@17.0.8(i18next@26.3.4(typescript@5.9.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3):
+    dependencies:
+      '@babel/runtime': 7.29.7
+      html-parse-stringify: 3.0.1
+      i18next: 26.3.4(typescript@5.9.3)
+      react: 19.2.7
+      use-sync-external-store: 1.6.0(react@19.2.7)
+    optionalDependencies:
+      react-dom: 19.2.7(react@19.2.7)
+      typescript: 5.9.3
+
   react-remove-scroll-bar@2.3.8(@types/react@19.2.17)(react@19.2.7):
     dependencies:
       react: 19.2.7
@@ -2456,6 +2533,10 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
 
+  use-sync-external-store@1.6.0(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+
   vite@8.0.16(@types/node@25.9.4)(jiti@2.7.0):
     dependencies:
       lightningcss: 1.32.0
@@ -2467,6 +2548,8 @@ snapshots:
       '@types/node': 25.9.4
       fsevents: 2.3.3
       jiti: 2.7.0
+
+  void-elements@3.1.0: {}
 
   which@2.0.2:
     dependencies:

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -1,12 +1,15 @@
+import { useTranslation } from "react-i18next";
 import { SITE_CONFIG } from "@/lib/config";
 
 export function Footer() {
+  const { t } = useTranslation();
+
   return (
     <footer className="border-t mt-auto">
       <div className="container mx-auto px-4 py-6">
         <div className="flex flex-col md:flex-row items-center justify-between gap-4">
           <p className="text-sm text-muted-foreground">
-            © {new Date().getFullYear()} {SITE_CONFIG.name}. All rights reserved.
+            {t("footer.copyright", { year: new Date().getFullYear(), name: SITE_CONFIG.name })}
           </p>
           <div className="flex gap-4">
             <a
@@ -15,7 +18,7 @@ export function Footer() {
               rel="noopener noreferrer"
               className="text-sm text-muted-foreground hover:text-primary transition-colors"
             >
-              📁 Repository
+              {t("footer.repository")}
             </a>
           </div>
         </div>

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,26 +1,30 @@
 import { useState } from "react";
 import { Link } from "react-router-dom";
 import { Menu } from "lucide-react";
+import { useTranslation } from "react-i18next";
 import { ThemeToggle } from "./ThemeToggle";
+import { LanguageToggle } from "./LanguageToggle";
 import { SITE_CONFIG } from "@/lib/config";
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
 import { Button } from "@/components/ui/button";
 
-type NavItem = { to: string; label: string; external?: false } | { href: string; label: string; external: true };
+type NavItem = { to: string; labelKey: string; external?: false } | { href: string; labelKey: string; external: true };
 
 const NAV_ITEMS: NavItem[] = [
-  { to: "/", label: "Home" },
-  { to: "/about", label: "About" },
-  { to: "/projects", label: "Projects" },
-  { href: SITE_CONFIG.links.blog, label: "Blog", external: true },
-  { to: "/contact", label: "Contact" },
+  { to: "/", labelKey: "header.nav.home" },
+  { to: "/about", labelKey: "header.nav.about" },
+  { to: "/projects", labelKey: "header.nav.projects" },
+  { href: SITE_CONFIG.links.blog, labelKey: "header.nav.blog", external: true },
+  { to: "/contact", labelKey: "header.nav.contact" },
 ];
 
 function NavLinks({ onClick }: { onClick?: () => void }) {
+  const { t } = useTranslation();
+
   return (
     <>
       {NAV_ITEMS.map((item) => (
-        <li key={item.label}>
+        <li key={item.labelKey}>
           {item.external ? (
             <a
               href={item.href}
@@ -29,11 +33,11 @@ function NavLinks({ onClick }: { onClick?: () => void }) {
               className="hover:text-primary transition-colors"
               onClick={onClick}
             >
-              {item.label}
+              {t(item.labelKey)}
             </a>
           ) : (
             <Link to={item.to} className="hover:text-primary transition-colors" onClick={onClick}>
-              {item.label}
+              {t(item.labelKey)}
             </Link>
           )}
         </li>
@@ -43,6 +47,7 @@ function NavLinks({ onClick }: { onClick?: () => void }) {
 }
 
 export function Header() {
+  const { t } = useTranslation();
   const [open, setOpen] = useState(false);
 
   return (
@@ -58,15 +63,17 @@ export function Header() {
             <ul className="flex gap-6">
               <NavLinks />
             </ul>
+            <LanguageToggle />
             <ThemeToggle />
           </div>
 
           {/* Mobile Navigation */}
           <div className="md:hidden flex items-center gap-4">
+            <LanguageToggle />
             <ThemeToggle />
             <Sheet open={open} onOpenChange={setOpen}>
               <SheetTrigger asChild>
-                <Button variant="ghost" size="icon" aria-label="Open menu">
+                <Button variant="ghost" size="icon" aria-label={t("header.openMenu")}>
                   <Menu className="h-5 w-5" />
                 </Button>
               </SheetTrigger>

--- a/frontend/src/components/LanguageToggle.tsx
+++ b/frontend/src/components/LanguageToggle.tsx
@@ -10,7 +10,7 @@ const NEXT_LANGUAGE: Record<Language, Language> = {
 export function LanguageToggle() {
   const { t, i18n } = useTranslation();
 
-  const currentLanguage = (i18n.resolvedLanguage ?? LANGUAGES.EN) as Language;
+  const currentLanguage: Language = i18n.resolvedLanguage === LANGUAGES.JA ? LANGUAGES.JA : LANGUAGES.EN;
   const label = t(`language.${currentLanguage}`);
 
   const toggleLanguage = () => {

--- a/frontend/src/components/LanguageToggle.tsx
+++ b/frontend/src/components/LanguageToggle.tsx
@@ -1,0 +1,32 @@
+import { useTranslation } from "react-i18next";
+import { LANGUAGES, type Language } from "@/i18n/config";
+import { Button } from "@/components/ui/button";
+
+const NEXT_LANGUAGE: Record<Language, Language> = {
+  [LANGUAGES.EN]: LANGUAGES.JA,
+  [LANGUAGES.JA]: LANGUAGES.EN,
+};
+
+export function LanguageToggle() {
+  const { t, i18n } = useTranslation();
+
+  const currentLanguage = (i18n.resolvedLanguage ?? LANGUAGES.EN) as Language;
+  const label = t(`language.${currentLanguage}`);
+
+  const toggleLanguage = () => {
+    i18n.changeLanguage(NEXT_LANGUAGE[currentLanguage]);
+  };
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={toggleLanguage}
+      title={t("language.current", { label })}
+      data-testid="language-toggle"
+    >
+      <span className="text-sm font-semibold uppercase">{currentLanguage}</span>
+      <span className="sr-only">{t("language.toggle")}</span>
+    </Button>
+  );
+}

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -1,17 +1,20 @@
+import { useTranslation } from "react-i18next";
 import { useTheme } from "./ThemeProvider";
 import { THEMES, type Theme } from "./theme";
 import { Button } from "@/components/ui/button";
 
-const THEME_CONFIG: Record<Theme, { icon: string; label: string; next: Theme }> = {
-  [THEMES.LIGHT]: { icon: "☀️", label: "Light", next: THEMES.DARK },
-  [THEMES.DARK]: { icon: "🌙", label: "Dark", next: THEMES.SYSTEM },
-  [THEMES.SYSTEM]: { icon: "💻", label: "System", next: THEMES.LIGHT },
+const THEME_CONFIG: Record<Theme, { icon: string; next: Theme }> = {
+  [THEMES.LIGHT]: { icon: "☀️", next: THEMES.DARK },
+  [THEMES.DARK]: { icon: "🌙", next: THEMES.SYSTEM },
+  [THEMES.SYSTEM]: { icon: "💻", next: THEMES.LIGHT },
 };
 
 export function ThemeToggle() {
+  const { t } = useTranslation();
   const { theme, setTheme } = useTheme();
 
   const themeConfig = THEME_CONFIG[theme];
+  const label = t(`theme.${theme}`);
 
   const toggleTheme = () => {
     setTheme(themeConfig.next);
@@ -22,11 +25,11 @@ export function ThemeToggle() {
       variant="ghost"
       size="icon"
       onClick={toggleTheme}
-      title={`Current theme: ${themeConfig.label}`}
+      title={t("theme.current", { label })}
       className="relative"
     >
       <span className="text-lg">{themeConfig.icon}</span>
-      <span className="sr-only">Toggle theme</span>
+      <span className="sr-only">{t("theme.toggle")}</span>
     </Button>
   );
 }

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -3,10 +3,10 @@ import { useTheme } from "./ThemeProvider";
 import { THEMES, type Theme } from "./theme";
 import { Button } from "@/components/ui/button";
 
-const THEME_CONFIG: Record<Theme, { icon: string; next: Theme }> = {
-  [THEMES.LIGHT]: { icon: "☀️", next: THEMES.DARK },
-  [THEMES.DARK]: { icon: "🌙", next: THEMES.SYSTEM },
-  [THEMES.SYSTEM]: { icon: "💻", next: THEMES.LIGHT },
+const THEME_CONFIG: Record<Theme, { icon: string; next: Theme; labelKey: string }> = {
+  [THEMES.LIGHT]: { icon: "☀️", next: THEMES.DARK, labelKey: "theme.light" },
+  [THEMES.DARK]: { icon: "🌙", next: THEMES.SYSTEM, labelKey: "theme.dark" },
+  [THEMES.SYSTEM]: { icon: "💻", next: THEMES.LIGHT, labelKey: "theme.system" },
 };
 
 export function ThemeToggle() {
@@ -14,7 +14,7 @@ export function ThemeToggle() {
   const { theme, setTheme } = useTheme();
 
   const themeConfig = THEME_CONFIG[theme];
-  const label = t(`theme.${theme}`);
+  const label = t(themeConfig.labelKey);
 
   const toggleTheme = () => {
     setTheme(themeConfig.next);

--- a/frontend/src/components/UnderConstruction.tsx
+++ b/frontend/src/components/UnderConstruction.tsx
@@ -1,15 +1,19 @@
+import { useTranslation } from "react-i18next";
+
 interface UnderConstructionProps {
   pageName: string;
 }
 
 export function UnderConstruction({ pageName }: UnderConstructionProps) {
+  const { t } = useTranslation();
+
   return (
     <div className="container mx-auto px-4 py-16">
       <div className="max-w-2xl mx-auto text-center">
         <div className="text-6xl mb-8">🚧</div>
         <h1 className="text-4xl font-bold mb-4">{pageName}</h1>
-        <p className="text-xl text-muted-foreground mb-8">This page is currently under construction.</p>
-        <p className="text-muted-foreground">Check back soon for updates!</p>
+        <p className="text-xl text-muted-foreground mb-8">{t("underConstruction.message")}</p>
+        <p className="text-muted-foreground">{t("underConstruction.checkBack")}</p>
       </div>
     </div>
   );

--- a/frontend/src/i18n/config.ts
+++ b/frontend/src/i18n/config.ts
@@ -1,0 +1,36 @@
+import i18n from "i18next";
+import { initReactI18next } from "react-i18next";
+import LanguageDetector from "i18next-browser-languagedetector";
+import en from "./locales/en/translation.json";
+import ja from "./locales/ja/translation.json";
+
+export const LANGUAGE_STORAGE_KEY = "23prime-language";
+
+export const LANGUAGES = {
+  EN: "en",
+  JA: "ja",
+} as const;
+
+export type Language = (typeof LANGUAGES)[keyof typeof LANGUAGES];
+
+i18n
+  .use(LanguageDetector)
+  .use(initReactI18next)
+  .init({
+    resources: {
+      [LANGUAGES.EN]: { translation: en },
+      [LANGUAGES.JA]: { translation: ja },
+    },
+    fallbackLng: LANGUAGES.EN,
+    supportedLngs: Object.values(LANGUAGES),
+    detection: {
+      order: ["localStorage", "navigator"],
+      lookupLocalStorage: LANGUAGE_STORAGE_KEY,
+      caches: ["localStorage"],
+    },
+    interpolation: {
+      escapeValue: false,
+    },
+  });
+
+export default i18n;

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -1,0 +1,126 @@
+{
+  "header": {
+    "nav": {
+      "home": "Home",
+      "about": "About",
+      "projects": "Projects",
+      "blog": "Blog",
+      "contact": "Contact"
+    },
+    "openMenu": "Open menu"
+  },
+  "footer": {
+    "copyright": "© {{year}} {{name}}. All rights reserved.",
+    "repository": "📁 Repository"
+  },
+  "theme": {
+    "light": "Light",
+    "dark": "Dark",
+    "system": "System",
+    "current": "Current theme: {{label}}",
+    "toggle": "Toggle theme"
+  },
+  "language": {
+    "current": "Current language: {{label}}",
+    "toggle": "Toggle language",
+    "en": "English",
+    "ja": "Japanese"
+  },
+  "home": {
+    "greeting": "{{nickname}}@{{name}}",
+    "tagline": "Software Developer",
+    "cards": {
+      "about": {
+        "title": "About",
+        "description": "Learn more about my background and skills",
+        "button": "View Profile"
+      },
+      "projects": {
+        "title": "Projects",
+        "description": "Check out my portfolio and works",
+        "button": "View Projects"
+      },
+      "contact": {
+        "title": "Contact",
+        "description": "Get in touch with me",
+        "button": "Contact Me"
+      }
+    }
+  },
+  "about": {
+    "pageTitle": "About Me",
+    "profile": {
+      "heading": "Profile",
+      "job": { "label": "Job", "value": "Software Developer in Tokyo" },
+      "from": { "label": "From", "value": "Kofu, Yamanashi, Japan" },
+      "anotherSky": { "label": "Another Sky", "value": "Tsukuba, Ibaraki, Japan" },
+      "hobbies": { "label": "Hobbies", "value": "French Horn (orchestra), Gaming, Coffee" }
+    },
+    "history": {
+      "heading": "History",
+      "date": "Date",
+      "event": "Event",
+      "items": [
+        { "date": "1994/01", "event": "Born" },
+        { "date": "2017/03", "event": "Bachelor’s Degree in University of Tsukuba [mathematics]" },
+        { "date": "2019/03", "event": "Master’s Degree in University of Tsukuba [mathematics education]" },
+        {
+          "date": "2019/04",
+          "event": "Joined SATT, Inc. (Data Analysis -> Web Development -> AI Research -> ...)"
+        },
+        {
+          "date": "2024/10",
+          "event": "[NOW] Transferred to The Division of Technology Strategy (founding member)"
+        }
+      ]
+    },
+    "projects": {
+      "heading": "Projects & Products at work",
+      "role": "Role",
+      "visitWebsite": "Visit Website →",
+      "items": [
+        {
+          "title": "Authentication Platform Development",
+          "descriptions": ["Developed an OpenID Connect provider for internal web services."],
+          "role": "Programmer / SE"
+        },
+        {
+          "title": "ICT Learning system",
+          "descriptions": [
+            "Developed web-based learning materials for university entrance exams.",
+            "As well as a coaching/teaching system for teachers, and management system for staffs."
+          ],
+          "role": "Tech Lead"
+        }
+      ]
+    },
+    "techStack": {
+      "heading": "Tech Stack",
+      "categories": {
+        "languages": "Languages",
+        "webFrameworks": "Web Frameworks",
+        "infrastructure": "Infrastructure",
+        "otherWebTechnologies": "Other web technologies",
+        "databases": "Databases",
+        "tools": "Tools",
+        "practicesAndMethodologies": "Practices & Methodologies"
+      }
+    }
+  },
+  "projects": {
+    "pageName": "Projects"
+  },
+  "contact": {
+    "pageTitle": "Contact",
+    "description": "Feel free to reach out to me through any of the following channels.",
+    "links": {
+      "twitter": "Twitter",
+      "github": "GitHub",
+      "email": "Email"
+    }
+  },
+  "underConstruction": {
+    "message": "This page is currently under construction.",
+    "checkBack": "Check back soon for updates!"
+  }
+}

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -1,0 +1,126 @@
+{
+  "header": {
+    "nav": {
+      "home": "ホーム",
+      "about": "自己紹介",
+      "projects": "プロジェクト",
+      "blog": "ブログ",
+      "contact": "連絡先"
+    },
+    "openMenu": "メニューを開く"
+  },
+  "footer": {
+    "copyright": "© {{year}} {{name}}. All rights reserved.",
+    "repository": "📁 リポジトリ"
+  },
+  "theme": {
+    "light": "ライト",
+    "dark": "ダーク",
+    "system": "システム",
+    "current": "現在のテーマ: {{label}}",
+    "toggle": "テーマを切り替え"
+  },
+  "language": {
+    "current": "現在の言語: {{label}}",
+    "toggle": "言語を切り替え",
+    "en": "英語",
+    "ja": "日本語"
+  },
+  "home": {
+    "greeting": "{{nickname}}@{{name}}",
+    "tagline": "ソフトウェアエンジニア",
+    "cards": {
+      "about": {
+        "title": "自己紹介",
+        "description": "経歴やスキルについて詳しく紹介しています",
+        "button": "プロフィールを見る"
+      },
+      "projects": {
+        "title": "プロジェクト",
+        "description": "ポートフォリオや制作物を紹介しています",
+        "button": "プロジェクトを見る"
+      },
+      "contact": {
+        "title": "連絡先",
+        "description": "お気軽にご連絡ください",
+        "button": "連絡する"
+      }
+    }
+  },
+  "about": {
+    "pageTitle": "自己紹介",
+    "profile": {
+      "heading": "プロフィール",
+      "job": { "label": "職業", "value": "東京在住のソフトウェアエンジニア" },
+      "from": { "label": "出身", "value": "山梨県甲府市" },
+      "anotherSky": { "label": "第二の故郷", "value": "茨城県つくば市" },
+      "hobbies": { "label": "趣味", "value": "ホルン（オーケストラ）、ゲーム、コーヒー" }
+    },
+    "history": {
+      "heading": "経歴",
+      "date": "年月",
+      "event": "出来事",
+      "items": [
+        { "date": "1994/01", "event": "誕生" },
+        { "date": "2017/03", "event": "筑波大学 理工学群 数学類 卒業（学士）" },
+        { "date": "2019/03", "event": "筑波大学大学院 数学教育専攻 修了（修士）" },
+        {
+          "date": "2019/04",
+          "event": "株式会社SATT 入社（データ分析 → Web開発 → AI研究 → ...）"
+        },
+        {
+          "date": "2024/10",
+          "event": "【現在】技術戦略室へ異動（設立メンバー）"
+        }
+      ]
+    },
+    "projects": {
+      "heading": "業務でのプロジェクト・プロダクト",
+      "role": "役割",
+      "visitWebsite": "サイトを見る →",
+      "items": [
+        {
+          "title": "認証基盤の開発",
+          "descriptions": ["社内Webサービス向けのOpenID Connectプロバイダーを開発。"],
+          "role": "プログラマー / SE"
+        },
+        {
+          "title": "ICT学習システム",
+          "descriptions": [
+            "大学受験対策のためのWebベース学習教材を開発。",
+            "教員向けの指導支援システムや、スタッフ向けの管理システムも開発。"
+          ],
+          "role": "テックリード"
+        }
+      ]
+    },
+    "techStack": {
+      "heading": "技術スタック",
+      "categories": {
+        "languages": "言語",
+        "webFrameworks": "Webフレームワーク",
+        "infrastructure": "インフラ",
+        "otherWebTechnologies": "その他のWeb技術",
+        "databases": "データベース",
+        "tools": "ツール",
+        "practicesAndMethodologies": "プラクティス・方法論"
+      }
+    }
+  },
+  "projects": {
+    "pageName": "プロジェクト"
+  },
+  "contact": {
+    "pageTitle": "連絡先",
+    "description": "以下のいずれかの方法でお気軽にご連絡ください。",
+    "links": {
+      "twitter": "Twitter",
+      "github": "GitHub",
+      "email": "メール"
+    }
+  },
+  "underConstruction": {
+    "message": "このページは現在準備中です。",
+    "checkBack": "近日公開予定です。しばらくお待ちください。"
+  }
+}

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -28,21 +28,21 @@
   },
   "home": {
     "greeting": "{{nickname}}@{{name}}",
-    "tagline": "ソフトウェアエンジニア",
+    "tagline": "Software Developer",
     "cards": {
       "about": {
         "title": "自己紹介",
-        "description": "経歴やスキルについて詳しく紹介しています",
+        "description": "経歴やスキル",
         "button": "プロフィールを見る"
       },
       "projects": {
         "title": "プロジェクト",
-        "description": "ポートフォリオや制作物を紹介しています",
+        "description": "ポートフォリオや制作物",
         "button": "プロジェクトを見る"
       },
       "contact": {
         "title": "連絡先",
-        "description": "お気軽にご連絡ください",
+        "description": "お気軽にご連絡ください！",
         "button": "連絡する"
       }
     }
@@ -51,9 +51,9 @@
     "pageTitle": "自己紹介",
     "profile": {
       "heading": "プロフィール",
-      "job": { "label": "職業", "value": "東京在住のソフトウェアエンジニア" },
+      "job": { "label": "職業", "value": "東京ソフトウェア開発を生業にしている。" },
       "from": { "label": "出身", "value": "山梨県甲府市" },
-      "anotherSky": { "label": "第二の故郷", "value": "茨城県つくば市" },
+      "anotherSky": { "label": "アナザースカイ", "value": "茨城県つくば市" },
       "hobbies": { "label": "趣味", "value": "ホルン（オーケストラ）、ゲーム、コーヒー" }
     },
     "history": {
@@ -66,11 +66,11 @@
         { "date": "2019/03", "event": "筑波大学大学院 数学教育専攻 修了（修士）" },
         {
           "date": "2019/04",
-          "event": "株式会社SATT 入社（データ分析 → Web開発 → AI研究 → ...）"
+          "event": "SATT株式会社 入社（データ分析 → Web開発 → 人工知能研究所 → ...）"
         },
         {
           "date": "2024/10",
-          "event": "【現在】技術戦略室へ異動（設立メンバー）"
+          "event": "【現在】技術戦略室へ異動（発足メンバー）"
         }
       ]
     },
@@ -81,13 +81,13 @@
       "items": [
         {
           "title": "認証基盤の開発",
-          "descriptions": ["社内Webサービス向けのOpenID Connectプロバイダーを開発。"],
+          "descriptions": ["社内 Web サービス向けの OpenID Connect プロバイダーを開発。"],
           "role": "プログラマー / SE"
         },
         {
           "title": "ICT学習システム",
           "descriptions": [
-            "大学受験対策のためのWebベース学習教材を開発。",
+            "大学受験対策のための Web ベース学習教材を開発。",
             "教員向けの指導支援システムや、スタッフ向けの管理システムも開発。"
           ],
           "role": "テックリード"
@@ -121,6 +121,6 @@
   },
   "underConstruction": {
     "message": "このページは現在準備中です。",
-    "checkBack": "近日公開予定です。しばらくお待ちください。"
+    "checkBack": "気が向いたら作ります。"
   }
 }

--- a/frontend/src/lib/config.ts
+++ b/frontend/src/lib/config.ts
@@ -1,7 +1,6 @@
 export const SITE_CONFIG = {
   name: "23prime",
   nickname: "Okkey",
-  title: "Software Developer",
   profileImage: "/23prime.png",
   email: "okkey@mail.23prime.xyz",
   links: {

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import "./index.css";
+import "./i18n/config";
 import App from "./App.tsx";
 
 createRoot(document.getElementById("root")!).render(

--- a/frontend/src/pages/About.tsx
+++ b/frontend/src/pages/About.tsx
@@ -1,44 +1,16 @@
+import { useTranslation } from "react-i18next";
 import { SITE_CONFIG } from "@/lib/config";
 
-const PROFILE = [
-  { icon: "💻", item: "Job", value: "Software Developer in Tokyo" },
-  { icon: "🏠", item: "From", value: "Kofu, Yamanashi, Japan" },
-  { icon: "✈️", item: "Another Sky", value: "Tsukuba, Ibaraki, Japan" },
-  { icon: "🎺", item: "Hobbies", value: "French Horn (orchestra), Gaming, Coffee" },
+const PROFILE_ITEMS = [
+  { icon: "💻", key: "job" },
+  { icon: "🏠", key: "from" },
+  { icon: "✈️", key: "anotherSky" },
+  { icon: "🎺", key: "hobbies" },
 ] as const;
-
-const HISTORY = [
-  { date: "1994/01", event: "Born" },
-  { date: "2017/03", event: "Bachelor’s Degree in University of Tsukuba [mathematics]" },
-  { date: "2019/03", event: "Master’s Degree in University of Tsukuba [mathematics education]" },
-  { date: "2019/04", event: "Joined SATT, Inc. (Data Analysis -> Web Development -> AI Research -> ...)" },
-  { date: "2024/10", event: "[NOW] Transferred to The Division of Technology Strategy (founding member)" },
-] as const;
-
-const PROJECTS: ReadonlyArray<{
-  title: string;
-  descriptions: string[];
-  role: string;
-  link?: string;
-}> = [
-  {
-    title: "Authentication Platform Development",
-    descriptions: ["Developed an OpenID Connect provider for internal web services."],
-    role: "Programmer / SE",
-  },
-  {
-    title: "ICT Learning system",
-    descriptions: [
-      "Developed web-based learning materials for university entrance exams.",
-      "As well as a coaching/teaching system for teachers, and management system for staffs.",
-    ],
-    role: "Tech Lead",
-  },
-];
 
 const TECH_STACK = [
   {
-    category: "Languages",
+    categoryKey: "languages",
     items: [
       "Java",
       "Ruby",
@@ -57,38 +29,45 @@ const TECH_STACK = [
     ],
   },
   {
-    category: "Web Frameworks",
+    categoryKey: "webFrameworks",
     items: ["Spring Framework", "Rails", "Actix Web", "Nuxt.js/Vue.js", "React"],
   },
   {
-    category: "Infrastructure",
+    categoryKey: "infrastructure",
     items: ["AWS", "Docker", "Terraform"],
   },
   {
-    category: "Other web technologies",
+    categoryKey: "otherWebTechnologies",
     items: ["Nginx", "GraphQL", "gRPC", "OpenAPI"],
   },
   {
-    category: "Databases",
+    categoryKey: "databases",
     items: ["PostgreSQL", "MySQL", "Oracle Database", "MongoDB", "Redis"],
   },
   {
-    category: "Tools",
+    categoryKey: "tools",
     items: ["Git/GitHub", "GitHub Actions", "Visual Studio Code", "Emacs", "Zsh", "tmux", "Guake", "Arch Linux"],
   },
   {
-    category: "Practices & Methodologies",
+    categoryKey: "practicesAndMethodologies",
     items: ["TDD/BDD", "DDD", "SOLID", "Clean Architecture", "Onion Architecture"],
   },
 ] as const;
 
+type HistoryItem = { date: string; event: string };
+type ProjectItem = { title: string; descriptions: string[]; role: string; link?: string };
+
 export function About() {
+  const { t } = useTranslation();
+  const history = t("about.history.items", { returnObjects: true }) as HistoryItem[];
+  const projects = t("about.projects.items", { returnObjects: true }) as ProjectItem[];
+
   return (
     <div className="container mx-auto px-4 py-16">
       <div className="max-w-4xl mx-auto">
         {/* Header */}
         <div className="mb-12">
-          <h1 className="text-4xl font-bold mb-4">About Me</h1>
+          <h1 className="text-4xl font-bold mb-4">{t("about.pageTitle")}</h1>
           <p className="text-xl text-muted-foreground">
             {SITE_CONFIG.nickname}@{SITE_CONFIG.name}
           </p>
@@ -96,14 +75,14 @@ export function About() {
 
         {/* Profile Section */}
         <section className="mb-12">
-          <h2 className="text-2xl font-semibold mb-4">Profile</h2>
+          <h2 className="text-2xl font-semibold mb-4">{t("about.profile.heading")}</h2>
           <div className="space-y-2 text-muted-foreground">
-            {PROFILE.map((item) => (
-              <p key={item.item}>
+            {PROFILE_ITEMS.map((item) => (
+              <p key={item.key}>
                 <span className="font-medium">
-                  {item.icon} {item.item}:
+                  {item.icon} {t(`about.profile.${item.key}.label`)}:
                 </span>{" "}
-                {item.value}{" "}
+                {t(`about.profile.${item.key}.value`)}{" "}
               </p>
             ))}
           </div>
@@ -111,21 +90,21 @@ export function About() {
 
         {/* History */}
         <section className="mb-12">
-          <h2 className="text-2xl font-semibold mb-4">History</h2>
+          <h2 className="text-2xl font-semibold mb-4">{t("about.history.heading")}</h2>
           <div className="border rounded-lg overflow-hidden">
             <table className="w-full">
               <thead className="bg-muted">
                 <tr>
                   <th scope="col" className="text-left py-3 px-4 font-semibold">
-                    Date
+                    {t("about.history.date")}
                   </th>
                   <th scope="col" className="text-left py-3 px-4 font-semibold">
-                    Event
+                    {t("about.history.event")}
                   </th>
                 </tr>
               </thead>
               <tbody>
-                {HISTORY.map((item, index) => (
+                {history.map((item, index) => (
                   <tr key={item.date} className={index % 2 === 0 ? "bg-card" : "bg-muted/50"}>
                     <td className="py-3 px-4 whitespace-nowrap">{item.date}</td>
                     <td className="py-3 px-4">{item.event}</td>
@@ -138,9 +117,9 @@ export function About() {
 
         {/* Projects */}
         <section className="mb-12">
-          <h2 className="text-2xl font-semibold mb-4">Projects & Products at work</h2>
+          <h2 className="text-2xl font-semibold mb-4">{t("about.projects.heading")}</h2>
           <div className="space-y-4">
-            {PROJECTS.map((project) => (
+            {projects.map((project) => (
               <div key={project.title} className="border rounded-lg p-6 bg-card">
                 <h3 className="text-lg font-semibold mb-2">{project.title}</h3>
                 <p className="text-muted-foreground mb-2">
@@ -149,7 +128,7 @@ export function About() {
                   ))}
                 </p>
                 <p className="text-sm">
-                  <span className="font-medium">Role:</span> {project.role}
+                  <span className="font-medium">{t("about.projects.role")}:</span> {project.role}
                 </p>
                 {project.link && (
                   <a
@@ -158,7 +137,7 @@ export function About() {
                     rel="noopener noreferrer"
                     className="text-sm text-blue-600 dark:text-blue-400 hover:underline inline-block mt-2"
                   >
-                    Visit Website →
+                    {t("about.projects.visitWebsite")}
                   </a>
                 )}
               </div>
@@ -168,11 +147,11 @@ export function About() {
 
         {/* Tech Stack */}
         <section className="mb-12">
-          <h2 className="text-2xl font-semibold mb-4">Tech Stack</h2>
+          <h2 className="text-2xl font-semibold mb-4">{t("about.techStack.heading")}</h2>
           <div className="space-y-6">
             {TECH_STACK.map((group) => (
-              <div key={group.category}>
-                <h3 className="text-lg font-semibold mb-3">{group.category}</h3>
+              <div key={group.categoryKey}>
+                <h3 className="text-lg font-semibold mb-3">{t(`about.techStack.categories.${group.categoryKey}`)}</h3>
                 <div className="flex flex-wrap gap-2">
                   {group.items.map((item) => (
                     <span key={item} className="px-3 py-1 bg-secondary text-secondary-foreground rounded-md text-sm">

--- a/frontend/src/pages/Contact.tsx
+++ b/frontend/src/pages/Contact.tsx
@@ -1,41 +1,48 @@
+import { useTranslation } from "react-i18next";
 import { SITE_CONFIG } from "@/lib/config";
 import { ContactLink } from "@/components/ContactLink";
 
 const CONTACT_LINKS = [
   {
     icon: "🐦",
-    label: "Twitter",
+    key: "twitter",
     href: SITE_CONFIG.links.twitter,
     external: true,
   },
   {
     icon: "💻",
-    label: "GitHub",
+    key: "github",
     href: SITE_CONFIG.links.github,
     external: true,
   },
   {
     icon: "📧",
-    label: "Email",
+    key: "email",
     href: `mailto:${SITE_CONFIG.email}`,
     external: false,
   },
 ] as const;
 
 export function Contact() {
+  const { t } = useTranslation();
+
   return (
     <div className="container mx-auto px-4 py-16">
       <div className="max-w-2xl mx-auto">
         <div className="text-center mb-12">
-          <h1 className="text-4xl font-bold mb-4">Contact</h1>
-          <p className="text-xl text-muted-foreground">
-            Feel free to reach out to me through any of the following channels.
-          </p>
+          <h1 className="text-4xl font-bold mb-4">{t("contact.pageTitle")}</h1>
+          <p className="text-xl text-muted-foreground">{t("contact.description")}</p>
         </div>
 
         <div>
           {CONTACT_LINKS.map((link) => (
-            <ContactLink key={link.label} {...link} />
+            <ContactLink
+              key={link.key}
+              icon={link.icon}
+              label={t(`contact.links.${link.key}`)}
+              href={link.href}
+              external={link.external}
+            />
           ))}
         </div>
       </div>

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,28 +1,16 @@
+import { useTranslation } from "react-i18next";
 import { NavigationCard } from "@/components/NavigationCard";
 import { SITE_CONFIG } from "@/lib/config";
 
 const NAVIGATION_CARDS = [
-  {
-    to: "/about",
-    title: "About",
-    description: "Learn more about my background and skills",
-    buttonText: "View Profile",
-  },
-  {
-    to: "/projects",
-    title: "Projects",
-    description: "Check out my portfolio and works",
-    buttonText: "View Projects",
-  },
-  {
-    to: "/contact",
-    title: "Contact",
-    description: "Get in touch with me",
-    buttonText: "Contact Me",
-  },
+  { to: "/about", key: "about" },
+  { to: "/projects", key: "projects" },
+  { to: "/contact", key: "contact" },
 ] as const;
 
 export function Home() {
+  const { t } = useTranslation();
+
   return (
     <div className="container mx-auto px-4 py-16">
       <div className="max-w-4xl mx-auto">
@@ -36,15 +24,21 @@ export function Home() {
             />
           </div>
           <h1 className="text-4xl font-bold mb-4">
-            {SITE_CONFIG.nickname}@{SITE_CONFIG.name}
+            {t("home.greeting", { nickname: SITE_CONFIG.nickname, name: SITE_CONFIG.name })}
           </h1>
-          <p className="text-xl text-muted-foreground">{SITE_CONFIG.title}</p>
+          <p className="text-xl text-muted-foreground">{t("home.tagline")}</p>
         </div>
 
         {/* Navigation Cards */}
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
           {NAVIGATION_CARDS.map((card) => (
-            <NavigationCard key={card.to} {...card} />
+            <NavigationCard
+              key={card.to}
+              to={card.to}
+              title={t(`home.cards.${card.key}.title`)}
+              description={t(`home.cards.${card.key}.description`)}
+              buttonText={t(`home.cards.${card.key}.button`)}
+            />
           ))}
         </div>
       </div>

--- a/frontend/src/pages/Projects.tsx
+++ b/frontend/src/pages/Projects.tsx
@@ -1,5 +1,8 @@
+import { useTranslation } from "react-i18next";
 import { UnderConstruction } from "@/components/UnderConstruction";
 
 export function Projects() {
-  return <UnderConstruction pageName="Projects" />;
+  const { t } = useTranslation();
+
+  return <UnderConstruction pageName={t("projects.pageName")} />;
 }

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -10,6 +10,7 @@
 
     /* Bundler mode */
     "moduleResolution": "bundler",
+    "resolveJsonModule": true,
     "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true,
     "moduleDetection": "force",


### PR DESCRIPTION
## Checklist

- [ ] Status checks are passing
- [x] Target branch is correct

## Summary

Adds English/Japanese i18n support across the whole site using `react-i18next`.

## Reason for change

Closes #289. The site was English-only; this lets visitors browse in their preferred language.

## Changes

- Introduce `react-i18next` + `i18next-browser-languagedetector`, initialized in `src/i18n/config.ts`
- Add `en`/`ja` translation resources under `src/i18n/locales/`
- Initial language is auto-detected from the browser (`navigator.language`), with a manual toggle (`LanguageToggle`) in the Header
- Selected language persists to `localStorage` (`23prime-language`)
- Replace hardcoded strings across Header, Footer, ThemeToggle, UnderConstruction, and all pages (Home/About/Projects/Contact) with translation keys
- Add e2e coverage (`e2e/tests/language-toggle.spec.ts`) for the toggle, persistence, and browser-language detection; pin Playwright's default locale to `en-US` so existing English-text assertions stay deterministic

## Notes

- `mise run fe-check` and `mise run e2e-test` are both green locally (86/86 e2e tests)