### PR TITLE
ci: add workflow to detect and fix mise.lock drift

### DIFF
--- a/.github/workflows/check-mise-lock.yml
+++ b/.github/workflows/check-mise-lock.yml
@@ -1,0 +1,58 @@
+name: Check mise lock
+
+# Note:
+# Renovate's mise manager can update mise.lock itself, but doing so runs `mise lock`,
+# which Renovate treats as an unsafe execution requiring `allowedUnsafeExecutions`
+# in the bot/admin config. That's a self-hosted-only setting, unavailable to the
+# Mend-hosted Renovate GitHub App this repo uses, so Renovate PRs only bump mise.toml
+# and leave mise.lock stale. This workflow re-locks it whenever that drift appears.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "mise.toml"
+      - "mise.lock"
+      - ".github/workflows/check-mise-lock.yml"
+  pull_request:
+    paths:
+      - "mise.toml"
+      - "mise.lock"
+      - ".github/workflows/check-mise-lock.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # push auto-fix commits
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install mise
+        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+        with:
+          install: false
+          cache: true
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Fix
+        run: mise run lock-fix
+
+      - name: Commit and Push
+        uses: 23prime/simple-commit-and-push@15fb653b9591afde3bffb82a906a9af2aede1616 # v1.0.0
+        with:
+          commit-message: "Auto fix by workflow"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check
+        run: mise run lock-check

--- a/mise.toml
+++ b/mise.toml
@@ -95,6 +95,17 @@ description = "Check for leaked secrets"
 run = "betterleaks git --redact --no-banner"
 alias = "sca"
 
+# mise lock
+[tasks.lock-fix]
+description = "Update mise.lock"
+run = "mise lock"
+alias = "lf"
+
+[tasks.lock-check]
+description = "Check mise.lock is up to date"
+run = ["mise lock", "git diff --exit-code -- mise.lock"]
+alias = "lc"
+
 # Frontend
 [tasks.fe-install]
 description = "Install frontend dependencies"


### PR DESCRIPTION
## Checklist

- [x] Status checks are passing
- [x] Target branch is correct

## Summary

Add a CI workflow that keeps `mise.lock` in sync with `mise.toml`.

## Reason for change

Renovate's mise manager only rewrites `mise.toml`; it does not run `mise lock`. As a result `mise.lock` can silently fall out of sync (e.g. after a version bump like `markdownlint-cli2`). `postUpgradeTasks` was considered but is a self-hosted-only Renovate feature (`allowedCommands` must be set in the bot/admin config), which doesn't apply to the Mend-hosted Renovate GitHub App used here.

## Changes

- `mise.toml`: add `lock-fix` / `lock-check` tasks
- `.github/workflows/check-mise-lock.yml`: on changes to `mise.toml` / `mise.lock`, run `mise lock`, auto-commit and push any diff, then verify the lockfile is clean

## Notes

`mise.lock` in this repo was already in sync, so this PR doesn't touch it. Since Renovate PRs have `automerge: true`, this lets future lockfile drift get fixed and pushed automatically without manual intervention.

Same change as https://github.com/23prime/mise-template/pull/49.