### PR TITLE
ci: add cicd-sensor to GitHub Actions workflows

### DIFF
--- a/.github/workflows/check-empty.yml
+++ b/.github/workflows/check-empty.yml
@@ -19,5 +19,8 @@ jobs:
     permissions: {}
 
     steps:
+      - name: cicd-sensor
+        uses: cicd-sensor/cicd-sensor-action@31366296cb918b7f1413829aafc16dcf18fe8518 # v0.0.35
+
       - name: Exit successfully
         run: exit 0

--- a/.github/workflows/check-frontend.yml
+++ b/.github/workflows/check-frontend.yml
@@ -20,6 +20,9 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: cicd-sensor
+        uses: cicd-sensor/cicd-sensor-action@31366296cb918b7f1413829aafc16dcf18fe8518 # v0.0.35
+
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/check-github-workflow.yml
+++ b/.github/workflows/check-github-workflow.yml
@@ -20,6 +20,9 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: cicd-sensor
+        uses: cicd-sensor/cicd-sensor-action@31366296cb918b7f1413829aafc16dcf18fe8518 # v0.0.35
+
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/check-infrastructure.yml
+++ b/.github/workflows/check-infrastructure.yml
@@ -20,6 +20,9 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: cicd-sensor
+        uses: cicd-sensor/cicd-sensor-action@31366296cb918b7f1413829aafc16dcf18fe8518 # v0.0.35
+
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/check-markdown.yml
+++ b/.github/workflows/check-markdown.yml
@@ -24,6 +24,9 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: cicd-sensor
+        uses: cicd-sensor/cicd-sensor-action@31366296cb918b7f1413829aafc16dcf18fe8518 # v0.0.35
+
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/check-mise-lock.yml
+++ b/.github/workflows/check-mise-lock.yml
@@ -33,6 +33,9 @@ jobs:
     permissions:
       contents: write # push auto-fix commits
     steps:
+      - name: cicd-sensor
+        uses: cicd-sensor/cicd-sensor-action@31366296cb918b7f1413829aafc16dcf18fe8518 # v0.0.35
+
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/check-secrets.yml
+++ b/.github/workflows/check-secrets.yml
@@ -18,6 +18,9 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: cicd-sensor
+        uses: cicd-sensor/cicd-sensor-action@31366296cb918b7f1413829aafc16dcf18fe8518 # v0.0.35
+
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,9 @@ jobs:
       id-token: write
       contents: read
     steps:
+      - name: cicd-sensor
+        uses: cicd-sensor/cicd-sensor-action@31366296cb918b7f1413829aafc16dcf18fe8518 # v0.0.35
+
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:


### PR DESCRIPTION
## Checklist

- [x] Status checks are passing
- [x] Target branch is correct

## Summary

Add `cicd-sensor/cicd-sensor-action` as the first step of every job across all 8 GitHub Actions workflows.

## Reason for change

cicd-sensor is an eBPF-based CI/CD runtime security sensor that detects supply-chain attacks at runtime (e.g. credential theft triggered by a compromised dependency). Placing it as the first step of each job lets it monitor everything that runs afterward.

## Changes

- Added `cicd-sensor/cicd-sensor-action@31366296cb918b7f1413829aafc16dcf18fe8518 # v0.0.35` as the first step of every job in all 8 workflows under `.github/workflows/`.
- Pinned to v0.0.35 rather than the newest release (v0.0.36), per `renovate.json`'s `minimumReleaseAge: 3 days` policy — v0.0.36 was published less than 3 days ago.

## Notes

Mirrors the same change already applied and merged in `23prime/mise-template#52`. Closes #313.